### PR TITLE
Add BUILD_ARCH arg

### DIFF
--- a/digital_alchemy/Dockerfile
+++ b/digital_alchemy/Dockerfile
@@ -1,6 +1,8 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
+ARG BUILD_ARCH
+
 COPY install.sh /
 RUN /install.sh
 


### PR DESCRIPTION

## 📬 Changes

Adds an ARG for the BUILD_ARCH, to allow architecture detection.

The build args must be specified in the dockerfile, else they're just unset. The particular test configuration ([]) being used evals as an empty string when the var is unset.

- ...

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [ ] Tests (added, updated or not needed)
