### PR TITLE
TSX runtime

### DIFF
--- a/digital_alchemy/CHANGELOG.md
+++ b/digital_alchemy/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 24.9.1
+
+- Added support for tsx runtime.
+
+> ⚠️ node runtime is now legacy/deprecated, please update code
+
+`@digital-alchemy` has internally converted to `esm` exports. This update provides a compatible code runner experience.
+
+- [Updated deploy script](https://raw.githubusercontent.com/Digital-Alchemy-TS/haos-template/refs/heads/main/scripts/deploy.sh)
+- [ESM Migration Guide](https://docs.digital-alchemy.app/esm-migration)
+
 ## 24.8.3
 
 - getting it right

--- a/digital_alchemy/config.yaml
+++ b/digital_alchemy/config.yaml
@@ -14,7 +14,7 @@ arch:
 
 options:
   app_root: /share/digital_alchemy
-  main: src/main.js
+  main: src/main.ts
   node_env: production
   run_mode: tsx
 

--- a/digital_alchemy/config.yaml
+++ b/digital_alchemy/config.yaml
@@ -1,6 +1,6 @@
 name: "Code Runner"
 description: "Digital Alchemy code deployment runner"
-version: "24.8.3"
+version: "24.9.1"
 slug: "code_runner"
 url: https://github.com/Digital-Alchemy-TS/addons/tree/main/code_runner
 init: false

--- a/digital_alchemy/config.yaml
+++ b/digital_alchemy/config.yaml
@@ -16,11 +16,13 @@ options:
   app_root: /share/digital_alchemy
   main: src/main.js
   node_env: production
+  run_mode: tsx
 
 schema:
   app_root: str
   main: str
   node_env: str
+  run_mode: list(node|tsx)
 
 map:
   - share:rw

--- a/digital_alchemy/run.sh
+++ b/digital_alchemy/run.sh
@@ -4,6 +4,7 @@
 # Fetch configuration options
 APP_ROOT=$(bashio::config 'app_root')
 APP_MAIN=$(bashio::config 'main')
+RUN_MODE=$(bashio::config 'run_mode')
 
 # Navigate to the app root
 cd "${APP_ROOT}" || bashio::exit.nok "Could not navigate to application root: ${APP_ROOT}"
@@ -21,4 +22,9 @@ yarn install
 PACKAGE_NAME=$(jq -r '.name' package.json)
 bashio::log.info "Starting ${PACKAGE_NAME}..."
 
-node "$APP_MAIN"
+# Check run_mode and execute the corresponding command
+if [[ "${RUN_MODE}" == "tsx" ]]; then
+  npx tsx "$APP_MAIN"
+else
+  node "$APP_MAIN"
+fi

--- a/digital_alchemy/translations/en.yaml
+++ b/digital_alchemy/translations/en.yaml
@@ -4,4 +4,4 @@ configuration:
     description: Path to the folder containing package.json
   main:
     name: Entrypoint File
-    description: Make sure to use .js extension
+    description: Path to main.ts. Can be in your /config folder


### PR DESCRIPTION
## 📬 Changes



- Added support for tsx runtime.

> ⚠️ node runtime is now legacy/deprecated, please update code
`@digital-alchemy` has internally converted to `esm` exports. This update provides a compatible code runner experience.

- [Updated deploy script](https://raw.githubusercontent.com/Digital-Alchemy-TS/haos-template/refs/heads/main/scripts/deploy.sh)
- [ESM Migration Guide](https://docs.digital-alchemy.app/esm-migration)



## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [ ] Tests (added, updated or not needed)
