### PR TITLE
2026 builder migration

### DIFF
--- a/digital_alchemy/Dockerfile
+++ b/digital_alchemy/Dockerfile
@@ -1,11 +1,12 @@
-ARG BUILD_FROM
-FROM $BUILD_FROM
+FROM ghcr.io/home-assistant/base:3.24
 
 COPY install.sh /
-RUN /install.sh
+RUN /install.sh \
+    && addgroup -g 1000 code_runner \
+    && adduser -u 1000 -G code_runner -s /bin/sh -D code_runner
 
-# Copy data for add-on
 COPY run.sh /
 RUN chmod a+x /run.sh
 
+USER code_runner
 CMD [ "/run.sh" ]

--- a/digital_alchemy/Dockerfile
+++ b/digital_alchemy/Dockerfile
@@ -3,6 +3,7 @@ FROM ghcr.io/home-assistant/base:latest
 COPY install.sh /
 RUN /install.sh
 
+# Copy data for add-on
 COPY run.sh /
 RUN chmod a+x /run.sh
 

--- a/digital_alchemy/Dockerfile
+++ b/digital_alchemy/Dockerfile
@@ -1,12 +1,9 @@
-FROM ghcr.io/home-assistant/base:3.24
+FROM ghcr.io/home-assistant/base:latest
 
 COPY install.sh /
-RUN /install.sh \
-    && addgroup -g 1000 code_runner \
-    && adduser -u 1000 -G code_runner -s /bin/sh -D code_runner
+RUN /install.sh
 
 COPY run.sh /
 RUN chmod a+x /run.sh
 
-USER code_runner
 CMD [ "/run.sh" ]


### PR DESCRIPTION
Fixes #10 

https://developers.home-assistant.io/blog/2026/04/02/builder-migration/
https://developers.home-assistant.io/docs/apps/configuration/#app-dockerfile
https://github.com/home-assistant/supervisor/issues/6794

## 📬 Changes

`BUILD_FROM` is not longer provided and `FROM` needs to specified manually


## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
