### PR TITLE
Update install.sh and enforce 48 supply chain cooldown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
+# Digital Alchemy Addons
+
 ## 🚀 Installation
 
 [![Add repository on my Home Assistant][repository-badge]][repository-url]
 
 If you want to do add the repository manually, please follow the procedure highlighted in the [Home Assistant website](https://www.home-assistant.io/common-tasks/os#installing-third-party-add-ons).
-Use the following URL to add this repository: https://github.com/Digital-Alchemy-TS/addons
+Use the following URL to add this repository: <https://github.com/Digital-Alchemy-TS/addons>
 
 [repository-badge]: https://img.shields.io/badge/Add%20repository%20to%20my-Home%20Assistant-41BDF5?logo=home-assistant&style=for-the-badge
 [repository-url]: https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FDigital-Alchemy-TS%2Faddons

--- a/digital_alchemy/CHANGELOG.md
+++ b/digital_alchemy/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 26.8.5
+
+- install Bun via the official installer and Alpine `nodejs`/`npm` on both arches
+- remove glibc workarounds, unofficial Node musl builds, and unused global packages (`nodemon`, npm-installed `bun`)
+- enforce a 48-hour minimum release age on registry installs (npm / Yarn / Bun)
+
+## 26.8.4
+
+- fix add-on `url` to point at `digital_alchemy/` (was a 404 for `code_runner/`)
+- limit supported architectures to `aarch64` and `amd64`
+
 ## 25.7.1
 
 - added `corepack` to dependencies installed

--- a/digital_alchemy/DOCS.md
+++ b/digital_alchemy/DOCS.md
@@ -1,9 +1,12 @@
 # 🏃‍♀️ Digital Alchemy Code Runner
 
 This addon acts as a simple configurable execution container for applications based on Digital Alchemy.
-It comes with `Node20`, and is intended for working with builds of `@digital-alchemy` Home Automation applications.
+It defaults to the `bun` runtime, and also supports `node` and `tsx` via Alpine-packaged Node.js. It is intended for working with builds of `@digital-alchemy` Home Automation applications.
+
+Registry installs (npm / Yarn / Bun) skip package versions published in the last 48 hours as a supply-chain attack mitigation.
 
 - [Project docs](https://docs.digital-alchemy.app)
+- [Code Runner guide](https://docs.digital-alchemy.app/docs/home-automation/quickstart/haos/addon)
 - [Discord](https://discord.gg/JkZ35Gv97Y)
 
 ## Usage
@@ -40,7 +43,7 @@ yarn rollback
 ### 🔒 Providing Secrets
 
 `@digital-alchemy/core` has a built in configuration loader suitable for providing secrets to your application.
-A more complete description of the loader can be found in the [config documentation](https://docs.digital-alchemy.app/docs/core/configuration)
+A more complete description of the loader can be found in the [config and environment guide](https://docs.digital-alchemy.app/docs/core/guides/config-and-environment).
 
 Your application will automatically have access to Home Assistant within the addon, but if you wish to integrate with other tools that require API keys, these can be provided by several mechanisms.
 

--- a/digital_alchemy/Dockerfile
+++ b/digital_alchemy/Dockerfile
@@ -1,7 +1,9 @@
 FROM ghcr.io/home-assistant/base:latest
 
 COPY install.sh /
-RUN /install.sh
+RUN chmod a+x /install.sh \
+  && /install.sh \
+  && rm /install.sh
 
 # Copy data for add-on
 COPY run.sh /

--- a/digital_alchemy/config.yaml
+++ b/digital_alchemy/config.yaml
@@ -1,6 +1,6 @@
 name: "Code Runner"
 description: "Digital Alchemy code deployment runner"
-version: "26.8.4"
+version: "26.8.5"
 slug: "code_runner"
 url: https://github.com/Digital-Alchemy-TS/addons/tree/main/digital_alchemy
 init: false

--- a/digital_alchemy/install.sh
+++ b/digital_alchemy/install.sh
@@ -1,30 +1,18 @@
 #!/bin/sh
-ARCH=$(uname -m)
+set -e
 
-## 1) Bun
-# See issue for details on why this exists / when it will be replaced with something more sane
-# https://github.com/oven-sh/bun/issues/5545#issuecomment-1722461083
-if [ "$(uname -m)" = "aarch64" ]; then
-  # aarch64
-  wget https://raw.githubusercontent.com/squishyu/alpine-pkg-glibc-aarch64-bin/master/glibc-2.26-r1.apk
-  apk add --no-cache --allow-untrusted --force-overwrite glibc-2.26-r1.apk
-  rm glibc-2.26-r1.apk
-else
-  # x86_64
-  wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk
-  wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-  apk add --no-cache --force-overwrite glibc-2.28-r0.apk
-  rm glibc-2.28-r0.apk
-fi
+apk add --no-cache curl unzip libstdc++ libgcc
 
-## 2) Node
-if [ "$ARCH" = "x86_64" ]; then
-  NODE_VERSION=22.10.0
-  apk add --no-cache curl
-  curl -fsSL https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64-musl.tar.xz | tar -xJf - -C /usr/local --strip-components=1;
-else
-  apk add --no-cache curl nodejs npm
-fi
+# Install Bun onto PATH for the add-on runtime (non-login shell).
+BUN_INSTALL=/usr/local
+export BUN_INSTALL
+curl -fsSL https://bun.sh/install | bash
 
-## 3) Install runtimes
-npm i -g corepack tsx nodemon bun
+# Alpine-packaged Node — both arches, security updates via apk.
+# Needed for run_mode=node|tsx (and corepack/yarn).
+apk add --no-cache nodejs npm
+
+# Skip registry versions published in the last 48 hours (supply-chain cooldown).
+# --before works on Alpine's npm; min-release-age needs npm 11.10+.
+BEFORE=$(node -e 'console.log(new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString())')
+npm i -g corepack tsx --before="$BEFORE"

--- a/digital_alchemy/run.sh
+++ b/digital_alchemy/run.sh
@@ -25,16 +25,20 @@ if [[ ! -f "package.json" ]]; then
   bashio::exit.nok "package.json not found in APP_ROOT:'${APP_ROOT}'"
 fi
 
- if [[ "${RUN_MODE}" == "bun" ]]; then
-  # npm install -g bun
+# Skip registry versions published in the last 48 hours (supply-chain cooldown).
+MIN_RELEASE_AGE_SECS=$((48 * 60 * 60))
+
+if [[ "${RUN_MODE}" == "bun" ]]; then
   bun --version
-  bun install
+  bun install --minimum-release-age "${MIN_RELEASE_AGE_SECS}"
   bun run "$APP_MAIN"
 else
   corepack enable && corepack prepare yarn@stable --activate
   yarn config set compressionLevel mixed
   yarn config set nodeLinker node-modules
+  yarn config set npmMinimalAgeGate "2d"
   yarn install
+
 
   # Extract package name from package.json
   PACKAGE_NAME=$(jq -r '.name' package.json)


### PR DESCRIPTION
## 📬 Changes

- Cleanup/update install.sh now that bun ships with glibc
- Allows for unpinned node version for security updates
- Enforced 48 package age on bun and yarn to mitigate supply chain attacks
- Updates and cleanup in docs


## 🗒️ Checklist

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated)
